### PR TITLE
Integration of ujs-based import state methods, required for kbase-ui hosted bulk-ui tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 dev-user-token
 *password*
 api-documentation.json
@@ -10,3 +9,6 @@ npm-debug.log
 \#*\#
 
 config.json
+/nbproject/
+/tokens/
+/config/env.json

--- a/LICENSE
+++ b/LICENSE
@@ -1,22 +1,7 @@
-The MIT License (MIT)
+Copyright (c) 2016 The KBase Project and its Contributors
 
-Copyright (c) 2015 
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/add_acl.py
+++ b/add_acl.py
@@ -22,14 +22,18 @@ if not os.path.exists(args.sharedDir):
     os.makedirs(args.sharedDir)
     os.chmod(args.sharedDir, 0777)
 
-tc = TransferClient() # uses transfer_token from the config file
-auth = AuthClient()
+authToken = ''
+transferToken = ''
+endpointId = ''
+
+tc = TransferClient(authorizer=transferToken) # uses transfer_token from the config file
+auth = AuthClient(authorizer=authToken)
 
 identities = auth.get_identities(usernames="%s@globusid.org" % args.shareName)
 user_identity_id = identities['identities'][0]['id']
 try:
    tc.add_endpoint_acl_rule(
-       '3aca022a-5e5b-11e6-8309-22000b97daec',
+       endpointId,
        dict(principal=user_identity_id,
             principal_type='identity', path=args.sharedDir, permissions='rw'),
    )

--- a/config.json
+++ b/config.json
@@ -1,3 +1,0 @@
-{
-    "ftpRoot": "/data/bulktest"
-}

--- a/config/config-ci.json
+++ b/config/config-ci.json
@@ -1,0 +1,17 @@
+{
+    "ftpRoot": "/data/bulk",
+    "services": {
+        "user_job_state": {
+            "url": "https://ci.kbase.us/services/userandjobstate"
+        },
+        "login": {
+            "url": "https://ci.kbase.us/services/authorization/Sessions/Login"
+        }
+    },
+    "globus": {
+        "transfer_service_url": "https://transfer.api.globusonline.org/v0.10",
+        "nexus_service_url": "https://nexus.api.globusonline.org",
+        "auth_service_url": "https://auth.globus.org",
+        "endpointId": "0a6a2f14-89b3-11e6-b030-22000b92c261"
+    }
+}

--- a/config/config-next.json
+++ b/config/config-next.json
@@ -1,0 +1,18 @@
+{
+    "ftpRoot": "/data/bulk",
+    "services": {
+        "user_job_state": {
+            "url": "https://next.kbase.us/services/userandjobstate"
+        },
+        "login": {
+            "url": "https://next.kbase.us/services/authorization/Sessions/Login"
+        }
+    },
+    "globus": {
+        "transfer_service_url": "https://transfer.api.globusonline.org/v0.10",
+        "nexus_service_url": "https://nexus.api.globusonline.org",
+        "auth_service": "https://auth.globus.org",
+        "endpointId": "",
+        "shareId": ""
+    }
+}

--- a/config/config-prod.json
+++ b/config/config-prod.json
@@ -1,0 +1,18 @@
+{
+    "ftpRoot": "/data/bulk",
+    "services": {
+        "user_job_state": {
+            "url": "https://kbase.us/services/userandjobstate"
+        },
+        "login": {
+            "url": "https://kbase.us/services/authorization/Sessions/Login"
+        }
+    },
+    "globus": {
+        "transfer_service_url": "https://transfer.api.globusonline.org/v0.10",
+        "nexus_service_url": "https://nexus.api.globusonline.org",
+        "auth_service": "https://auth.globus.org",
+        "endpointId": "",
+        "shareId": ""
+    }
+}

--- a/docs/dev-deployment.md
+++ b/docs/dev-deployment.md
@@ -1,0 +1,118 @@
+# Developer Deployment 
+
+Following are notes for how I got the ftp api running, able to upload files,
+and able to share the files per-globus-user.
+
+Key to this is:
+
+- using nodejs 6.6
+- creating the shared data directory
+- creating a globus test account with special "plus" powers
+- create an endpoint
+- 
+
+
+## create vm
+
+- ubuntu 14.04
+- nodejs 6.6
+  - install as per: https://github.com/nodesource/distributions
+
+##  Clone the ftp api
+
+- vagrant ssh
+- cd /vagrant (or wherever)
+- git clone https://github.com/kbase/kb-ftp-api
+
+
+## create the ftp-api config
+
+- create kb-ftp-api/config/env.json
+- install node deps:
+    - npm install
+- add this:
+{
+    "deployment": "ci",
+    "globusAuthToken": "",
+    "globusTransferToken": ""
+}
+
+
+## create root data directory with rw access for the user who will be running it:
+
+- mkdir /data/shared
+- chmod 777 /data/shared
+
+## create test account at globus
+
+- create a new account at globus with an email address that routes to you
+- have dan add it to kbase plus
+    - this is required in order for it to conduct ACL modifications for other users
+
+## create personal setup key at globus
+
+- while logged in goto Manage Data > Endpoints
+- select "+ add Globus Connect Personal endpoint"
+- enter a display name, like "My test kbase bulk endpoint"
+- a "Setup Key" will be generated
+- keep this window open as you will need to copy it below
+
+## install globus connect personal
+
+- wget https://s3.amazonaws.com/connect.globusonline.org/linux/stable/globusconnectpersonal-latest.tgz
+- copy the setup key to the clipboard
+- run the client with the "setup" option
+- ./globusconnect -setup <your key>
+
+## create a sharing endopint
+
+By default, the personal endpoint cannot be partitioned into folders shared with specific users.
+In order to enable this, first the owner of the endpoint must be a plus users (see above).
+Secondly, you must create a shared endpoint at the root of the primary endpoint
+- while still logged in as the test user
+- navigate to Manage Data > Endpoints
+- select the endpoint you created
+- select the My Shares tab
+- there should be no shares showing
+- Click "Add Shared Endpoint"
+- Enter
+  - Host Path: /data/bulk
+     - this is the absolute path on the host (running globus connect personal)
+  - Share Display Name: SOMETHING
+     - this will be used to identify the shared endpoing both in the globus endpoint
+       management tool, and also in in the user endpoint management tool when it 
+       provides a searchable list of available endpoints
+  - Click "Create"
+- the globus endpoint tool will bring you to the shared endpoint on the Sharing tab
+- select the Overview tab
+- copy the value of the UUID field
+- paste this into the "endpointId" property in the config/confg-ci.json
+
+## start globus connect personal
+
+- ./globusconnect -debug -restrict-paths "rw,/data/bulk" -shared-paths "rw,/data/bulk"
+- this will run it in the foreground in chatty debug mode
+
+## get tokens for accessing globus via the api:
+
+- while still logged in to your test account
+- visit tokens.globus.org
+- get auth and transfer tokens for the test account
+- copy these tokens into the appropriate fields in env.json
+
+> Note: these tokens will work for two days. After two days you will need to 
+  generate fresh tokens and install them.
+
+## generate bulkio service token
+
+Ah, the main point of this refactoring was to move the service token from the ui to the back end.
+We generate the service token using the get-token.js script found in the kb-ftp-api root
+
+- node get-token.js username password > tokens/bulkio-service-token.json
+
+> Note: I've not been able to test this, since I didn't have access to the bulkio passowrd
+
+## Start the ftp api server
+cd /vagrant/kb-ftp-api
+nodejs server.js
+

--- a/get-token.js
+++ b/get-token.js
@@ -1,0 +1,22 @@
+'use strict';
+
+// usage: node get-token.js username password
+
+
+var username = process.argv[2];
+var password = process.argv[3];
+
+var env = require('./config/env.json');
+var config = require('./config/config-' + env.deployment + '.json');
+
+var url = config.services.login.url;
+
+var auth = require('./lib/auth').make({url: url, timeout: 10000});
+
+var token = auth.getToken(username, password)
+    .then(function (token) {
+        var out = {
+            token: token
+        };
+        process.stdout.write(JSON.stringify(out, null, 4));
+    });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,6 +2,7 @@ var gulp = require('gulp'),
     spawn = require('child_process').spawn,
     fs = require('fs');
 
+// not sure about this...
 var server;
 
 /**
@@ -9,10 +10,12 @@ var server;
  * Launch the server in dev mode.  If there's a server already running, kill it.
  * Rebuild docs on start and file change.
  */
-gulp.task('server', function() {
+gulp.task('server', function () {
     gulp.run('docs')
 
-    if (server) server.kill()
+    if (server) {
+        server.kill()
+    }
     server = spawn('node', ['server.js', '--dev'], {stdio: 'inherit'})
     server.on('close', function (code) {
         if (code === 8) {
@@ -25,7 +28,7 @@ gulp.task('server', function() {
  * $ gulp test
  * Run api tests via jasmine-node.
  */
-gulp.task('test', function() {
+gulp.task('test', function () {
     server = spawn('jasmine-node', ['./tests/'], {stdio: 'inherit'})
 })
 
@@ -34,7 +37,7 @@ gulp.task('test', function() {
  * $ gulp docs
  * Create web documentation data
  */
-gulp.task('docs', function() {
+gulp.task('docs', function () {
     var outputFile = './api-documentation.json'
     var stream = fs.createWriteStream(outputFile);
 
@@ -46,7 +49,7 @@ gulp.task('docs', function() {
     docs.on('close', function (code) {
         console.log('Wrote API documentation JSON to: ' + outputFile);
         //fs.createReadStream(outputFile).pipe(
-            //fs.createWriteStream('path to docs')
+        //fs.createWriteStream('path to docs')
         //);
     });
 })
@@ -56,15 +59,16 @@ gulp.task('docs', function() {
  * $ gulp
  * Start the development environment
  */
-gulp.task('default', function() {
+gulp.task('default', function () {
     gulp.run('server')
 
-    gulp.watch(['./server.js', './parsers/*.js', './docs/*.js'], function() {
+    gulp.watch(['./server.js', './parsers/*.js', './docs/*.js'], function () {
         gulp.run('server')
     })
 })
 
 // clean up if an error goes unhandled.
-process.on('exit', function() {
-    if (server) server.kill()
+process.on('exit', function () {
+    if (server)
+        server.kill()
 })

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,0 +1,55 @@
+'use strict';
+var request = require('request-promise');
+
+function factory(config)  {
+    var url = config.url,
+        timeout = config.timeout || 60000;
+    
+    if (!url) {
+        throw new TypeError('Auth login url is undefined');
+    }
+
+    function login(username, password) {
+        var loginParams = {
+            user_id: username,
+            password: password,
+            fields: 'un,token,user_id,kbase_sessionid,name',
+            status: 1
+        },
+            data = Object.keys(loginParams).map(function (key) {
+                return key + '=' + encodeURIComponent(loginParams[key]);
+            }).join('&');
+
+        var header = {};
+
+        header['Content-type'] = 'application/x-www-form-urlencoded';
+
+        return request({
+            url: url,
+            method: 'POST',
+            headers: header,
+            body: data
+        })
+            .then(function (body) {
+                return JSON.parse(body);
+            });
+    }
+    
+    function getToken(username, password) {
+        return login(username, password)
+            .then(function(result) {
+                return result.token;
+            });
+    }
+
+    return {
+        login: login,
+        getToken: getToken
+    };
+}
+
+module.exports = {
+    make: function (config) {
+        return factory(config);
+    }
+};

--- a/lib/globusTransfer.js
+++ b/lib/globusTransfer.js
@@ -1,0 +1,147 @@
+var request = require('request-promise');
+var utils = require('./utils');
+
+/*
+ * Provides methods for sharing a directory per user over globus transfer
+ */
+
+// given a "super user" for whom the endpoint client is already running
+// identified by an authToken (to fetch a user's identity)
+// and a transferToken (to set up the permissions on the directory) ...
+
+// get the tokens
+// TODO: get from config
+
+
+
+// get the userId of the user for whom the share is created
+// this is the same as a kbase username
+
+// get the identity id of the userId from globus. This is 
+// just a check to ensre that his a valid user...
+// but this should not really be necessary since the share
+// should fail if the user is not valid.
+// TODO perhaps implement this, but I don't think necessary.
+
+// call the add_endpoint_acl_rul with the given 
+// endpoint, userId, path, etc.
+
+/* https://docs.globus.org/api/transfer/acl/
+ * section 7.3:
+ * 
+ * POST /endpoint/<endpoint_xid>/access
+ * 
+ */
+
+/*
+ * nb globus embeds these urls in their example source code. That is
+ * part of their "magic". However, we dont' do that.
+ * https://github.com/globus/globus-sdk-python/blob/master/globus_sdk/globus.cfg
+ */
+
+function factory(config) {
+    'use strict';
+    var transferApiBase = config.transferApiBase,
+        authApiBase = config.authApiBase,
+        authToken = config.authToken,
+        transferToken = config.transferToken,
+        endpointId = config.endpointId;
+
+    function getUserIdentityId(username) {
+        var globusId = username + '@globusid.org',
+            url = [authApiBase, 'v2', 'api', 'identities'].join('/'),
+            query = {
+                usernames: globusId
+            },
+            header = {
+                Authorization: 'Bearer ' + authToken
+            };
+        return request({
+            method: 'GET',
+            url: url,
+            qs: query,
+            headers: header
+        })
+            .then(function (response) {
+                utils.log('INFO', `successfully fetched identity for ${username}`)
+                var result = JSON.parse(response);
+                return result.identities[0].id;
+            });
+    }
+    
+    function getRoles() {
+        var url = [transferApiBase, 'endpoint', endpointId, 'role_list'].join('/'),
+            header = {
+                Authorization: 'Bearer ' + transferToken,
+                'Content-Type': 'application/json'
+            };
+        return request({
+            method: 'GET',
+            url: url,
+            headers: header            
+        });
+    }
+
+    function getAccessList() {
+        var url = [transferApiBase, 'endpoint', endpointId, 'access_list'].join('/'),
+            header = {
+                Authorization: 'Bearer ' + transferToken,
+                'Content-Type': 'application/json'
+            };
+        return request({
+            method: 'GET',
+            url: url,
+            headers: header            
+        });
+    }
+
+    function addUserShare(username, path) {
+        var url = [transferApiBase, 'endpoint', endpointId, 'access'].join('/'),
+            header = {
+                Authorization: 'Bearer  ' + transferToken,
+                'Content-Type': 'application/json'
+            },
+            data = {
+                DATA_TYPE: 'access',
+                principal_type: 'identity',
+                path: ['', username, ''].join('/'),
+                permissions: 'rw'
+            };
+        return getUserIdentityId(username)
+            .then(function (userIdentityId) {
+                data.principal = userIdentityId;
+                return request({
+                    method: 'POST',
+                    url: url,
+                    headers: header,
+                    body: JSON.stringify(data)
+                });
+            })
+            .then(function (result) {
+                utils.log('INFO', `Successfully added user share for ${username}`);
+                return result;
+            })
+            .catch(function (err) {
+                // handle error conditions as per the spec:
+                // rethrow as specific errors.
+                // console.log('ERROR', err);
+                utils.log('ERROR', 'error adding user share', err);
+                throw err;
+            });
+    }
+
+    return Object.freeze({
+        getUserIdentityId: getUserIdentityId,
+        addUserShare: addUserShare,
+        getRoles: getRoles,
+        getAccessList: getAccessList
+    });
+}
+
+
+module.exports = {
+    make: function (config) {
+        'use strict';
+        return factory(config);
+    }
+};

--- a/lib/serviceApiClient.js
+++ b/lib/serviceApiClient.js
@@ -1,0 +1,65 @@
+'use strict';
+var request = require('request-promise');
+
+function factory(config)  {
+    var url = config.url,
+        servicePrefix = config.name,
+        authToken = config.token,
+        timeout = config.timeout || 60000;
+    
+    if (!url) {
+        throw new TypeError('Service url is undefined');
+    }
+    if (!servicePrefix) {
+        throw new TypeError('Service name is undefined');
+    }
+
+    function rpcRequest(method, params) {
+        var rpc = {
+            params: params,
+            method: servicePrefix + '.' + method,
+            version: "1.1",
+            id: String(Math.random()).slice(2)
+        };
+
+        var header = {};
+        if (authToken) {
+            header.Authorization = authToken;
+        }
+
+        header['Content-type'] = 'application/x-www-form-urlencoded';
+
+        return request({
+            url: url,
+            method: 'POST',
+            headers: header,
+            body: JSON.stringify(rpc)
+        })
+            .then(function (body) {
+                try {
+                    // console.log('body', body);
+                    var data = JSON.parse(body);
+                    if (data && data instanceof Object && data !== null) {
+                        var result = data.result;
+                        if (result && result instanceof Array) {
+                            return result[0];
+                        }
+                        return result;
+                    }
+                    throw new Error('Error with result format for ' + servicePrefix + ', ' + method + ', ' + body);
+                } catch (ex) {
+                    throw new Error('Error parsing result for ' + servicePrefix + ', ' + method + ', ' + body + ':' + ex.message);
+                }
+            });
+    }
+
+    return {
+        rpcRequest: rpcRequest
+    };
+}
+
+module.exports = {
+    make: function (config) {
+        return factory(config);
+    }
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,9 @@
+'use strict';
+
+function log(label, message, data) {
+    console.log([new Date().toISOString(), label, message].join(':'), data ? JSON.stringify(data): '');
+}
+
+module.exports = {
+    log: log
+};

--- a/lib/validateToken.js
+++ b/lib/validateToken.js
@@ -1,9 +1,10 @@
-var userIdRegex = /un=(\w+\@\w+(\.\w+))/;
 var crypto = require("crypto");
 var request = require('request');
 var defer = require('promised-io/promise').defer;
 var when = require("promised-io/promise").when;
+var utils = require('./utils');
 
+var userIdRegex = /un=(\w+\@\w+(\.\w+))/;
 var ss_cache = {};
 
 getSigner = function(signer){
@@ -17,15 +18,15 @@ getSigner = function(signer){
         def.resolve(body.pubkey);
     });
     return def.promise;
-}
+};
 
 var validateToken = function(token){
     var parts = token.split("|");
-    var parsedToken = {}
-    var baseToken = []
+    var parsedToken = {};
+    var baseToken = [];
     parts.forEach(function(part){
         var tuple = part.split("=");
-        if (tuple[0]!="sig"){
+        if (tuple[0] !== "sig"){
             baseToken.push(part);
         }
         parsedToken[tuple[0]]=tuple[1];
@@ -43,29 +44,32 @@ var validateToken = function(token){
     return when(getSigner(parsedToken.SigningSubject), function(signer){
         var verifier = crypto.createVerify("RSA-SHA1");
         verifier.update(baseToken.join("|"));
-        var success = verifier.verify(signer.toString("ascii"),parsedToken.sig,"hex")
+        var success = verifier.verify(signer.toString("ascii"),parsedToken.sig,"hex");
         return success;
-    }, function(err){
-        console.log("Error retrieving SigningSubject: ", parsedToken.SigningSubject);
+    }, function(err) {
+        utils.log('ERROR', "Error retrieving SigningSubject: ", parsedToken.SigningSubject);
         return false;
     });
 
-}
+};
 
 module.exports = function(token) {
     return when(validateToken(token), function(valid){
         if (!valid) {
-            console.log("Invalid Token");
+            utils.log('ERROR', "Invalid Token");
             return false;
         }
 
-        var user = {id: token.split('|')[0].replace('un=', '')}
+        var user = {
+            id: token.split('|')[0].replace('un=', ''),
+            token: token
+        };
 
-        console.log("User from token: ", user.id);
+        // console.log("User from token: ", user.id);
         if (user && user.id) {
             return user;
         }
         return false;
     });
 
-}
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "kb-ftp-api",
-  "version": "0.0.0",
   "description": "JSON HTTP API for user's FTP space in KBase  ",
   "main": "server.js",
   "directories": {
@@ -12,29 +11,29 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/nconrad/kb-ftp-api"
+    "url": "https://github.com/kbase/kb-ftp-api"
   },
   "author": "",
-  "license": "ISC",
+  "license": "SEE LICENSE IN LICENSE",
   "bugs": {
-    "url": "https://github.com/nconrad/kb-ftp-api/issues"
+    "url": "https://github.com/kbase/kb-ftp-api/issues"
   },
-  "homepage": "https://github.com/nconrad/kb-ftp-api",
+  "homepage": "https://github.com/kbase/kb-ftp-api",
   "dependencies": {
-    "apidoc": "^0.13.1",
-    "body-parser": "^1.15.0",
-    "comment-parser": "^0.3.0",
-    "cors": "^2.7.1",
-    "express": "^4.13.3",
-    "jasmine-node": "^1.14.5",
-    "multer": "^1.2.0",
-    "nodemailer": "^2.2.1",
-    "promise": "^7.1.1",
-    "promised-io": "^0.3.5",
-    "q": "^1.4.1",
-    "request": "^2.65.0",
-    "request-promise": "^2.0.1",
-    "socket.io": "^1.3.7"
+    "apidoc": "0.16.1",
+    "bluebird": "3.4.6",
+    "body-parser": "1.15.2",
+    "comment-parser": "0.3.1",
+    "cors": "2.8.1",
+    "express": "4.14.0",
+    "jasmine-node": "1.14.5",
+    "multer": "1.2.0",
+    "nodemailer": "2.6.4",
+    "promise": "7.1.1",
+    "promised-io": "0.3.5",
+    "request": "2.75.0",
+    "request-promise": "2.0.1",
+    "socket.io": "1.4.8"
   },
   "devDependencies": {
     "commander": "^2.9.0",

--- a/server.js
+++ b/server.js
@@ -1,42 +1,62 @@
-#!/usr/bin/env node
+/*global process*/
+/*jslint white:true,node:true,single:true,multivar:true,es6:true*/
+// #!/usr/bin/env node
 'use strict';
 
-// application config
-var config = require('./config.json');
+// External dependencies
+var app = require('express')(),
+    multer = require('multer'),
+    http = require('http').Server(app),
+    cors = require('cors'),
+    bodyParser = require('body-parser'),
+    request = require('request'),
+    extend = require('util')._extend,
+    cliOptions = require('commander'),
+    Promise = require('bluebird'),
+    fs = Promise.promisifyAll(require('fs')),
+    pathUtil = require('path'),
+    // execSync = require('child_process').execSync,
+    Promise = require('promise'),
+    when = require("promised-io/promise").when;
 
-var app             = require('express')(),
-    multer          = require('multer'),
-    http            = require('http').Server(app),
-    cors            = require('cors'),
-    bodyParser      = require('body-parser');
-
-var request         = require('request'),
-    extend          = require('util')._extend,
-    cliOptions 	    = require('commander'),
-    fs              = require('fs'),
-    pathUtil        = require('path'),
-    execSync        = require('child_process').execSync,
-    Promise         = require('promise'),
-    when            = require("promised-io/promise").when;
-
-var validateToken 	= require('./lib/validateToken.js');
+// Internal deps
+var validateToken = require('./lib/validateToken.js'),
+    serviceApiClientFactory = require('./lib/serviceApiClient'),
+    transferClient = require('./lib/globusTransfer'),
+    utils = require('./lib/utils');
 
 
+cliOptions.version('0.1.0')
+    .option('-d, --dev', 'Developer mode; this option attempts to use a token in the file: dev-user-token')
+    .parse(process.argv);
 
-cliOptions.version('0.0.1')
-           .option('-d, --dev', 'Developer mode; this option attempts to use a token in the file: dev-user-token')
-           .parse(process.argv);
+// Configuration
+/*
+ * The "env" config file stores volative configuration. It should be created
+ * per-deployment. E.g. it switches to one of the "config-ENV.json" files
+ * which have per-deployment configuration.
+ */
+var env = require('./config/env.json');
+var config = require('./config/config-' + env.deployment + '.json');
+
+// Get the bulkio service token. This token must be set at deployment time
+// via the usage of the script 'get-bulkio-token.js'.
+// TODO:perhaps this should be placed into "env.json", that being stated
+// as the home for volatile configuration.
+var serviceToken = require('./tokens/bulkio-service-token.json').token;
+
 
 // Configure CORs and body parser.
-app.use( cors() )
-   .use( bodyParser.urlencoded({extended: false, limit: '50mb'}) );
+app.use(cors())
+    .use(bodyParser.urlencoded({extended: false, limit: '50mb'}))
+    .use(bodyParser.json());
 
 
 // if --dev option is used, set token to token in file "./dev-user-token"
 // otherwise, pass on token for all routes, if there is one
 if (cliOptions.dev) {
     let token = fs.readFileSync('dev-user-token', 'utf8').trim();
-    console.log('\n\x1b[36m'+'using development token:'+'\x1b[0m', token, '\n')
+    console.log('\n\x1b[36m' + 'using development token:' + '\x1b[0m', token, '\n');
 
     app.all('/', (req, res, next) => {
         req.headers = {"Authorization": token};
@@ -44,34 +64,118 @@ if (cliOptions.dev) {
     }).use((req, res, next) => {
         req.headers = {"Authorization": token};
         next();
-    })
+    });
 }
 
-// handle desination of uploads
+
+// handle desination of uploads. The "multer" package provides for 
+// multipart transfers.
 let storage = multer.diskStorage({
     destination: (req, file, cb) => {
-        
+
         // if multiple files, take path of first
         let reqPath = req.body.destPath;
         let path = reqPath instanceof Array ? reqPath[0] : reqPath;
-        let securedReq = securePath(req.user.id, path)
-        
-        file.reqPath = securedReq.path+file.originalname;
-        file.serverPath = config.ftpRoot+securedReq.path;
-        cb(null, file.serverPath);        
+        let securedReq = securePath(req.user.id, path);
+
+        file.reqPath = securedReq.path + file.originalname;
+        file.serverPath = config.ftpRoot + securedReq.path;
+        cb(null, file.serverPath);
     },
     filename: (req, file, cb) => {
         // save file to <path>.part first, and then move to <path>        
-        cb(null, file.originalname+'.part')
+        cb(null, file.originalname + '.part');
     }
-})
+});
 
 // Configure Logging
-app.use( (req, res, next) => {
-    console.log('%s %s', req.method, req.url);
+app.use((req, res, next) => {
+    utils.log('INFO', `${req.method} ${req.url}`);
     next();
 });
 
+/*
+ * Since fs.exists is deprecated, this gives us an equivalent async
+ * method.
+ */
+function fileExists(path) {
+    return fs.accessAsync(path)
+        .then(() => {
+            return true;
+        })
+        .catch((err) => {
+            if (err.code === 'ENOENT') {
+                return false;
+            }
+            throw err;
+        });
+}
+
+function AuthRequired(req, res, next) {
+    // if no token at all, return 401
+    if (!('authorization' in req.headers)) {
+        res.status(401).send({error: 'Auth is required!'});
+    }
+
+    when(validateToken(req.headers.authorization),
+        userObj => {
+            if (!(userObj && 'id' in userObj)) {
+                res.status(401).send({error: 'Invalid token!'});
+                return;
+            }
+
+            // Pass user id along
+            req.user = userObj;
+
+            // safe to move along.
+            next();
+        });
+}
+
+/* 
+ * Given a username and a requested path, ensure that the username matches
+ * the username component of the path.
+ * returns the requested home and the path with user's home in path
+*/
+function securePath(username, path) {
+    let pathList = path.split('/').filter( (s) => {
+        return s.length === 0 ? false : true;
+    });
+    let home = pathList.shift();
+    
+    if (home !== username) {
+        utils.log('ERROR', 'Username does not match path prefix', {username: username, path: path, home: home});
+        throw new Error('User (' + username + ')' +
+            ' does not have permission to access: ' + path + '(' + home + ')');
+    }
+
+    // replace user with authenticated user
+    // why not just take a path without user originally, instead of swapping and
+    // later  matching the
+    // authenticated user and the path user (later)/
+    let allowedPath = ['', username].concat(pathList).concat('').join('/');
+
+    return {
+        requestedHome: home,
+        path: allowedPath
+    };
+}
+
+/*
+ * Async wrapping of move ...
+ * TODO: this should just be using renameAsync, since we've alreay wrapped
+ * fs in bluebird.
+ */
+function move(oldPath, newPath) {
+    return new Promise((resolve, reject) => {
+        fs.rename(oldPath, newPath, function (err) {
+            if (err)
+                reject('could not move .part file; ' + oldPath + ' => ' + newPath);
+            else
+                resolve();
+        });
+    });
+}
 
 /**
  * @api {get} /list/:path list files/folders in path
@@ -92,210 +196,268 @@ app.use( (req, res, next) => {
  *           size: 476
  *       }, {
  *           name: "blue-zebra",
-  *          mtime: 1458347601000,
+ *          mtime: 1458347601000,
  *           size: 170,
  *           isFolder: true
  *       }
  *     ]
  */
-app.get('/v0/list/*', AuthRequired, (req, res) => {
-    console.log('req.user.id:', req.user.id);    
+app.get('/list/*', AuthRequired, (req, res) => {
     const user = req.user.id,
-          opts = req.query;
+        fileListOptions = req.query;
 
     const requestedPath = req.params[0];
-    const securedReq = securePath(user, requestedPath);
-
-    // throw error if user doesn't have access
-    if (user != securedReq.requestedHome) {
-        let msg = 'User ('+user+')'+
-                ' does not have permission to access: '
-                + requestedPath
-        res.status(403).send({error: msg});
+    try {
+        var securedReq = securePath(user, requestedPath);
+    } catch (ex) {
+        res.status(403).send({error: ex.message});
         return;
     }
 
     const rootDir = config.ftpRoot,
-          path = securedReq.path,
-          fullPath = rootDir+path;
+        path = securedReq.path,
+        fullPath = rootDir + path,
+        userDir = [rootDir, user].join('/');
 
-    // check if user has home
-    let hasHome = false;
-    try {
-        hasHome = fs.statSync(rootDir+'/'+user).isDirectory();        
-    } catch(e) {
-        console.log("User's home not found:", user);
-    }
+    fileExists(userDir)
+        .then(function (exists) {
+            /*
+             * If a directory does not exist for this user, 
+             * create a directory and give the user RW access via globus
+             * transfer ACL.
+             */
+            if (!exists) {
+                return fs.mkdirAsync(userDir)
+                    .then(() => {
+                        var client = transferClient.make({
+                            authApiBase: config.globus.auth_service_url,
+                            transferApiBase: config.globus.transfer_service_url,
+                            authToken: env.globusAuthToken,
+                            transferToken: env.globusTransferToken,
+                            endpointId: config.globus.endpointId
+                        });
 
-    // if needed, create user's directory and enable acl's
-    if (!hasHome) {
-        let scriptPath = '/root/add_acl_dolson.py';
-        try {
-            let scriptRes = execSync(scriptPath+' --share-dir="'+rootDir+'/'+
-                user+'/" --share-name="'+user+'"');
-        } catch(e) {
-            let msg = 'User ('+user+')'+
-                ' does not have a directory and server could not run share script: '
-                + scriptPath
-
-            console.log(msg);
-            res.status(500).send({error: msg});
-            return;
-        }
-    }
-
-    // generate list of objects describing contents
-    let files = [];
-    fs.readdirSync(fullPath).forEach( (file) => {
-        let filePath = pathUtil.join(fullPath, file),
-            stats = fs.statSync(filePath),
-            isDir = stats.isDirectory();
-
-        if (opts.type === 'file' && isDir) return;
-        if (opts.type === 'folder' && !isDir) return;
-
-        let fileObj = {
-            name: file,
-            path: path+file,
-            mtime: stats.mtime.getTime(),
-            size: stats.size
-        }
-
-        // additional info if is directory
-        if (isDir) {
-            fileObj.isFolder = true;
-            //fileObj.folderCount = parseInt( execSync('find "' +
-            //    filePath+'" -maxdepth 1 -type d | wc -l').toString() ) - 1;
-        }
-
-        files.push(fileObj);
-    });
-
-    res.send(files);
-})
-
-
-/**
- * @api {get} /upload post endpoint to upload data
- * @apiName upload
- *
- * @apiSampleRequest /upload/
- *
- * @apiSuccess {json} meta meta on data uploaded
- * @apiSuccessExample {json} Success-Response:
- *     HTTP/1.1 200 OK
- *     [{
-            "path": "/nconrad/Athaliana.TAIR10_GeneAtlas_Experiments.tsv",
-            "size": 3190639,
-            "encoding": "7bit",
-            "name": "Athaliana.TAIR10_GeneAtlas_Experiments.tsv"
-        }, {
-            "path": "/nconrad/Sandbox_Experiments-1.tsv",
-            "size": 4309,
-            "encoding": "7bit",
-            "name": "Sandbox_Experiments-1.tsv"
-        }]
- */
-.post("/v0/upload",  AuthRequired, multer({ storage: storage }).array('uploads', 12), 
-    (req, res) => {
-    let user = req.user.id;
-
-    let proms = [],
-        log = [], 
-        response = [];
-
-    req.files.forEach(f => {
-        log.push(f.reqPath);
-        response.push({
-            path: f.reqPath,            
-            name: f.originalname,        
-            size: f.size,
-            mtime: Date.now()
-        })
-
-        proms.push( move(f.path, f.serverPath+f.originalname) )
-    })
-
-    Promise.all(proms).then((result) => {
-        console.log('user ('+user+') uploaded:\n', log.join('\n') )
-        res.send(response);
-    }).catch((error) => {
-        console.log('move error', error)
-    })
-})
-
-
-
-
-/**
- * @api {get} /test-service/  Way to test simple, unauthenticated GET request.
- *  Note: no version "v0", "v1", etc, in the endpoint.
- *
- * @apiName test-service
- *
- * @apiSampleRequest /test-server/
- *
- * @apiSuccess {json} string Should return code 200 with string
- *  "This is just a test. This is only a test."
- *
- */
-.get('/test-service', (req, res) => {
-    res.status(200).send( 'This is just a test. This is only a test.' );
-})
-
-
-function AuthRequired(req, res, next) {
-    // if no token at all, return 401
-    if (!('authorization' in req.headers)) {
-        res.status(401).send( {error: 'Auth is required!'} );
-    }
-
-    when(validateToken(req.headers.authorization),
-        userObj => {
-            if (!(userObj && 'id' in userObj)) {
-                res.status(401).send( {error: 'Invalid token!'} );
-                return;
+                        return client.addUserShare(user, config.ftpRoot);
+                    });
             }
-
-            // Pass user id along
-            req.user = userObj;
-
-            // safe to move along.
-            next();
         })
-}
+        .then(function () {
+            /*
+             * Return a list of the file contents. Note that there is some
+             * filtering here -- the request may ask for files or folders.
+             * 
+             */
+            return fs.readdirAsync(fullPath)
+                .then(function (files) {
+                    /*
+                     * Note that we use map + filter pattern
+                     */
+                    return files.map((file) => {
+                        let filePath = pathUtil.join(fullPath, file),
+                            stats = fs.statSync(filePath),
+                            isDir = stats.isDirectory();
 
-// takes user and requested path
-// returns the requested home and the path with user's home in path
-function securePath(user, path) {
-    let pathList = path.split('/').filter(s => { 
-        if (s !== '') return true;
-    })
-    let home = pathList.shift();
+                        if (fileListOptions.type === 'file' && isDir) {
+                            return;
+                        }
+                        if (fileListOptions.type === 'folder' && !isDir) {
+                            return;
+                        }
 
-    // replace user with authenticated user
-    let allowedPath = '/'+user+'/'+pathList.join('/')+'/';    
-
-    return {
-        requestedHome: home,
-        path: allowedPath
-    }
-}
-
-function move(oldPath, newPath) {
-    return new Promise((resolve, reject) => {
-        fs.rename(oldPath, newPath, function (err) {
-            if (err) 
-                reject('could not move .part file; '+oldPath+' => '+newPath);
-            else 
-                resolve();
+                        return {
+                            name: file,
+                            path: path + file,
+                            mtime: stats.mtime.getTime(),
+                            size: stats.size,
+                            isFolder: isDir ? true : false
+                        };
+                    })
+                        .filter((fileObj) => {
+                            if (!fileObj) {
+                                return false;
+                            }
+                            return true;
+                        });
+                });
+        })
+        .then(function (files) {
+            res.send(files);
+        })
+        .catch(function (err) {
+            utils.log('ERROR', 'Error listing directory contents', {error: err});
+            res.status(500).send({error: err});
         });
+})
+
+
+    /**
+     * @api {get} /upload post endpoint to upload data
+     * @apiName upload
+     *
+     * @apiSampleRequest /upload/
+     *
+     * @apiSuccess {json} meta meta on data uploaded
+     * @apiSuccessExample {json} Success-Response:
+     *     HTTP/1.1 200 OK
+     *     [{
+     "path": "/nconrad/Athaliana.TAIR10_GeneAtlas_Experiments.tsv",
+     "size": 3190639,
+     "encoding": "7bit",
+     "name": "Athaliana.TAIR10_GeneAtlas_Experiments.tsv"
+     }, {
+     "path": "/nconrad/Sandbox_Experiments-1.tsv",
+     "size": 4309,
+     "encoding": "7bit",
+     "name": "Sandbox_Experiments-1.tsv"
+     }]
+     */
+    .post("/upload", AuthRequired, multer({storage: storage}).array('uploads', 12),
+        (req, res) => {
+        let user = req.user.id;
+
+        let proms = [],
+            log = [],
+            response = [];
+
+        req.files.forEach(f => {
+            log.push(f.reqPath);
+            response.push({
+                path: f.reqPath,
+                name: f.originalname,
+                size: f.size,
+                mtime: Date.now()
+            });
+
+            proms.push(move(f.path, f.serverPath + f.originalname));
+        });
+
+        Promise.all(proms)
+            .then(() => {
+                utils.log('INFO', 'user (' + user + ') uploaded:\n', log.join('\n'));
+                res.send(response);
+            })
+            .catch((error) => {
+                // TODO: this error should propagate!
+                utils.log('ERROR', 'move error', error);
+            });
+    })
+
+    /**
+     * @api {get} /test-service/  Way to test simple, unauthenticated GET request.
+     *  Note: no version "v0", "v1", etc, in the endpoint.
+     *
+     * @apiName test-service
+     *
+     * @apiSampleRequest /test-server/
+     *
+     * @apiSuccess {json} string Should return code 200 with string
+     *  "This is just a test. This is only a test."
+     *
+     */
+    .get('/test-service', (req, res) => {
+        res.status(200).send('This is just a test. This is only a test.');
     });
-}
+
+/*
+ * Handle import ujs operations:
+ * - post /import-jobs : create a ujs job for the given actual jobs. Returns ujs job id
+ * - get /import-jobs : return all import jobs for this user
+ * - delete /import-job/JOB_ID : delete import job for this user
+ */
+app
+    .post('/import-jobs', AuthRequired, (req, res) => {
+        /*
+         * Creates an import-jobs record in UJS. The UJS job description
+         * stores a list of of import job ids provided, and the 
+         * job status stores the object id for the target narrative.
+         * The progress and completion are not used, so are set to sensible dummy values.
+         */
+        var ujs = serviceApiClientFactory.make({
+            name: 'UserAndJobState',
+            url: config.services.user_job_state.url,
+            token: req.user.token
+        }),
+            jobStatus = req.body.narrativeObjectId,
+            jobDescription = req.body.jobIds.join(','),
+            progress = {ptype: 'percent'},
+            completionEstimate = '9999-04-03T08:56:32+0000';
+
+        ujs.rpcRequest('create_and_start_job', [serviceToken, jobStatus, jobDescription, progress, completionEstimate])
+            .then(function (results) {
+                res.status(200).send({result: results});
+            })
+            .catch(function (err) {
+                utils.log('ERROR', 'Error creating import job', {error: err});
+                res.status(500).send({error: err});
+            });
+    })
+    .get('/import-jobs', AuthRequired, (req, res) => {
+        /*
+         * Fetch all the ujs import job records for this user.
+         */
+        var ujs = serviceApiClientFactory.make({
+            name: 'UserAndJobState',
+            url: config.services.user_job_state.url,
+            token: req.user.token
+        });
+        ujs.rpcRequest('list_jobs', [['bulkio'], ''])
+            .then(function (results) {
+                res.status(200).send({result: results});
+            })
+            .catch(function (err) {
+                utils.log('ERROR', 'Error listing import jobs', {error: err});
+                res.status(500).send({error: err});
+            });
+    })
+    .get('/import-job/:jobid', AuthRequired, (req, res) => {
+        /*
+         * Fetch the ujs job info for a given ujs job id.
+         */
+        var ujs = serviceApiClientFactory.make({
+            name: 'UserAndJobState',
+            url: config.services.user_job_state.url,
+            token: req.user.token
+        });
+        ujs.rpcRequest('get_job_info', [req.params.jobid])
+            .then(function (results) {
+                res.status(200).send({result: results});
+            })
+            .catch(function (err) {
+                utils.log('ERROR', 'Error getting import job info', {error: err});
+                res.status(500).send({error: err});
+            });
+
+    })
+    .delete('/import-job/:jobid', AuthRequired, (req, res) => {
+        /*
+         * Delete the given ujs job. This provides the UI function in which a
+         * user may remove an import job from their import listing panel. 
+         */
+        var ujs = serviceApiClientFactory.make({
+            name: 'UserAndJobState',
+            url: config.services.user_job_state.url,
+            token: req.user.token
+        }),
+            // for for now
+            jobIdToDelete = req.params.jobid;
+
+        ujs.rpcRequest('force_delete_job', [serviceToken, jobIdToDelete])
+            .then(function (results) {
+                // log('deleted import job', {results: results);
+                res.status(200).send({result: true});
+            })
+            .catch(function (err) {
+                utils.log('ERROR', 'error deleting import job', {error: err});
+                res.status(500).send({error: err});
+            });
+    });
+
+
+
 
 var server = http.listen(3000, () => {
     var host = server.address().address;
     var port = server.address().port;
 
-    console.log('Service listening at http://%s:%s', host, port);
+    utils.log('INFO', `Service listening at http://${host}:${port}`);
 });

--- a/testTransfer.js
+++ b/testTransfer.js
@@ -1,0 +1,36 @@
+var transferClient = require('./lib/globusTransfer');
+
+var authToken = '';
+
+var transferToken = '';
+
+// get the endpoint id
+
+// sharing endpoint
+var endpointId = '';
+
+var auth_service = 'https://auth.globus.org';
+var transfer_service = 'https://transfer.api.globusonline.org/v0.10';
+var nexus_service = 'https://nexus.api.globusonline.org';
+
+
+var client = transferClient.make({
+    authApiBase: auth_service,
+    transferApiBase: transfer_service,
+    authToken: authToken,
+    transferToken: transferToken,
+    endpointId: endpointId
+});
+
+var testuser = 'eaptest31';
+
+client.getUserIdentityId(testuser)
+    .then(function (result) {
+        console.log(result);
+    })
+    .catch(function (err) {
+            console.log('ERROR', err);
+    });
+    
+client.addUserShare(testuser, '/data/bulk')
+// client.getAccessList().then(function (result) {console.log(result)});


### PR DESCRIPTION
Originally hosted directly in the bulk-ui, moved into the back end in order remove exposure of the bulkio service token (required for ujs).
Also move the globus transfer acl operations into javascript, previously provided by calling out to a python script. This was done in order to allow better error capture, configuration, and easier deployment (no globus libraries or python required.)
Deployment friendly tools added, including configuration, token generation, and documentation (for local development). Note that the dev deployment document was more of a memoir of the journey to get it up and running -- it would need to be exercised from scratch to complete missing steps or incomplete descriptions.
Todo: documentation (internal and external) for the additional api methods, tests, fully flesh out dev deployment document, create production deployment documentation. 
