### PR TITLE
First step toward using auth2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ config.json
 /nbproject/
 /tokens/
 /config/env.json
+coverage

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ node
 ## Local Installation
 
 ```
-git clone https://github.com/nconrad/kb-ftp-api.git
+git clone https://github.com/kbase/kb-ftp-api.git
 cd kb-ftp-api
 npm install
 ```

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ gulp
 
 ## Running Tests
 
+Running tests requires a file called `tests/test-cfg.json`. This is a JSON file with the expected structure:
+```
+{
+    "authToken": Valid authentication token string,
+    "userId": The user id linked to that token
+}
+```
 API tests are ran with `npm test` or `gulp test`.
 
 ```

--- a/README.md
+++ b/README.md
@@ -34,18 +34,29 @@ gulp
 
 ## Running Tests
 
-Running tests requires a file called `tests/test-cfg.json`. This is a JSON file with the expected structure:
+Running tests requires a little local setup. You'll need to do the following:
+1. **Set the test environment.**
+In `config/env.json` , set the deployment to "test". In the config directory, you can also modify `config-test.json` to your liking. Mainly, you'll need to set the "ftpRoot" key to a local directory of your choosing, that will be modified by the tests.
+
+2. **Make a local file storage directory.**
+As mentioned above, you need a local directory to act as a dummy FTP root. Create that and set it in `config/config-test.json`
+
+3. **Set the test configuration.**
+Running tests requires a file called `tests/test-cfg.json`. This is a JSON file with the following structure:
 ```
 {
     "authToken": Valid authentication token string,
     "userId": The user id linked to that token
 }
 ```
-API tests are ran with `npm test` or `gulp test`.
 
+4. **Start a server.**
 ```
-npm test
+node server.js
 ```
+
+5. **Run the tests.**
+API tests are run with `npm test` or `gulp test`.
 
 
 ## Building Web Documentation

--- a/config/config-ci.json
+++ b/config/config-ci.json
@@ -6,6 +6,9 @@
         },
         "login": {
             "url": "https://ci.kbase.us/services/authorization/Sessions/Login"
+        },
+        "auth": {
+            "url": "https://ci.kbase.us/services/auth"
         }
     },
     "globus": {

--- a/config/config-next.json
+++ b/config/config-next.json
@@ -6,6 +6,9 @@
         },
         "login": {
             "url": "https://next.kbase.us/services/authorization/Sessions/Login"
+        },
+        "auth": {
+            "url": "https://next.kbase.us/services/auth"
         }
     },
     "globus": {

--- a/config/config-prod.json
+++ b/config/config-prod.json
@@ -6,6 +6,9 @@
         },
         "login": {
             "url": "https://kbase.us/services/authorization/Sessions/Login"
+        },
+        "auth": {
+            "url": "https://kbase.us/services/auth"
         }
     },
     "globus": {

--- a/config/config-test.json
+++ b/config/config-test.json
@@ -1,0 +1,20 @@
+{
+    "ftpRoot": "./data/bulk",
+    "services": {
+        "user_job_state": {
+            "url": "https://ci.kbase.us/services/userandjobstate"
+        },
+        "login": {
+            "url": "https://ci.kbase.us/services/authorization/Sessions/Login"
+        },
+        "auth": {
+            "url": "https://ci.kbase.us/services/auth"
+        }
+    },
+    "globus": {
+        "transfer_service_url": "https://transfer.api.globusonline.org/v0.10",
+        "nexus_service_url": "https://nexus.api.globusonline.org",
+        "auth_service_url": "https://auth.globus.org",
+        "endpointId": "0a6a2f14-89b3-11e6-b030-22000b92c261"
+    }
+}

--- a/lib/validateToken.js
+++ b/lib/validateToken.js
@@ -1,75 +1,24 @@
-var crypto = require("crypto");
-var request = require('request');
-var defer = require('promised-io/promise').defer;
-var when = require("promised-io/promise").when;
-var utils = require('./utils');
+'use strict';
 
-var userIdRegex = /un=(\w+\@\w+(\.\w+))/;
-var ss_cache = {};
-
-getSigner = function(signer){
-    var def = new defer();
-    if (ss_cache[signer]){
-        def.resolve(ss_cache[signer]);
-    }
-    request.get({url:signer,json:true}, function(err,response,body){
-        if (err) { return def.reject(err); }
-        if (!body) { return def.reject("Empty Signature"); }
-        def.resolve(body.pubkey);
+var Request = require('request-promise');
+/**
+ * Given an auth token, fetch the user session information from
+ * the Auth service.
+ */
+var getUserSession = function(authHost, token) {
+    return Request({
+        url: authHost + '/api/V2/token',
+        method: 'GET',
+        headers: {
+            'Authorization': token
+        }
+    }).then(function(session) {
+        session = JSON.parse(session);
+        session.token = token;
+        return session;
     });
-    return def.promise;
 };
 
-var validateToken = function(token){
-    var parts = token.split("|");
-    var parsedToken = {};
-    var baseToken = [];
-    parts.forEach(function(part){
-        var tuple = part.split("=");
-        if (tuple[0] !== "sig"){
-            baseToken.push(part);
-        }
-        parsedToken[tuple[0]]=tuple[1];
-    });
-
-
-    var ssString = parsedToken.SigningSubject,
-    signingSubject = ssString.slice(0, ssString.lastIndexOf('/'));
-
-    if (signingSubject !== "https://nexus.api.globusonline.org/goauth/keys") {
-        return false;
-    }
-
-
-    return when(getSigner(parsedToken.SigningSubject), function(signer){
-        var verifier = crypto.createVerify("RSA-SHA1");
-        verifier.update(baseToken.join("|"));
-        var success = verifier.verify(signer.toString("ascii"),parsedToken.sig,"hex");
-        return success;
-    }, function(err) {
-        utils.log('ERROR', "Error retrieving SigningSubject: ", parsedToken.SigningSubject);
-        return false;
-    });
-
-};
-
-module.exports = function(token) {
-    return when(validateToken(token), function(valid){
-        if (!valid) {
-            utils.log('ERROR', "Invalid Token");
-            return false;
-        }
-
-        var user = {
-            id: token.split('|')[0].replace('un=', ''),
-            token: token
-        };
-
-        // console.log("User from token: ", user.id);
-        if (user && user.id) {
-            return user;
-        }
-        return false;
-    });
-
+module.exports = function(authHost, token) {
+    return getUserSession(authHost, token);
 };

--- a/lib/validateToken.js
+++ b/lib/validateToken.js
@@ -7,7 +7,7 @@ var Request = require('request-promise');
  */
 var getUserSession = function(authHost, token) {
     return Request({
-        url: authHost + '/api/V2/token',
+        url: authHost + '/api/V2/me',
         method: 'GET',
         headers: {
             'Authorization': token

--- a/lib/validateToken.js
+++ b/lib/validateToken.js
@@ -1,6 +1,6 @@
-'use strict';
+'use strict'
 
-var Request = require('request-promise');
+var Request = require('request-promise')
 /**
  * Given an auth token, fetch the user session information from
  * the Auth service.
@@ -12,13 +12,13 @@ var getUserSession = function(authHost, token) {
         headers: {
             'Authorization': token
         }
-    }).then(function(session) {
-        session = JSON.parse(session);
-        session.token = token;
-        return session;
-    });
-};
+    }).then(session => {
+        session = JSON.parse(session)
+        session.token = token
+        return session
+    })
+}
 
 module.exports = function(authHost, token) {
-    return getUserSession(authHost, token);
-};
+    return getUserSession(authHost, token)
+}

--- a/lib/validateToken.js
+++ b/lib/validateToken.js
@@ -15,15 +15,15 @@ var getUserSession = function(authHost, token) {
     }).then(session => {
         session = JSON.parse(session)
         session.token = token
-        var globusUser = null
+        var globusUserIds = []
         // find globus username(s) if any, and put *JUST THE USERNAME* in the globusUser key
         // otherwise, make it null
         session.idents.forEach(ident => {
             if (ident.provider === 'Globus') {
-                globusUser = ident.username
+                globusUserIds.push(ident.username)
             }
         })
-        session.globusUser = globusUser
+        session.globusUserIds = globusUserIds
         return session
     })
 }

--- a/lib/validateToken.js
+++ b/lib/validateToken.js
@@ -15,6 +15,15 @@ var getUserSession = function(authHost, token) {
     }).then(session => {
         session = JSON.parse(session)
         session.token = token
+        var globusUser = null
+        // find globus username(s) if any, and put *JUST THE USERNAME* in the globusUser key
+        // otherwise, make it null
+        session.idents.forEach(ident => {
+            if (ident.provider === 'Globus') {
+                globusUser = ident.username
+            }
+        })
+        session.globusUser = globusUser
         return session
     })
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "jasmine-node tests/",
+    "test": "jasmine-node tests",
     "start": "node server.js"
   },
   "repository": {
@@ -26,6 +26,7 @@
     "comment-parser": "0.3.1",
     "cors": "2.8.1",
     "express": "4.14.0",
+    "istanbul": "^0.4.5",
     "jasmine-node": "1.14.5",
     "multer": "1.2.0",
     "nodemailer": "2.6.4",

--- a/server.js
+++ b/server.js
@@ -116,7 +116,6 @@ function AuthRequired(req, res, next) {
     if (!('authorization' in req.headers)) {
         res.status(401).send({error: 'Auth is required!'});
     }
-    console.log(req.headers.authorization)
     validateToken(config.services.auth.url, req.headers.authorization)
     .then(sessionObj => {
         if (!sessionObj) {

--- a/server.js
+++ b/server.js
@@ -17,7 +17,7 @@ var app = require('express')(),
     pathUtil = require('path'),
     // execSync = require('child_process').execSync,
     Promise = require('promise'),
-    when = require("promised-io/promise").when;
+    when = require('promised-io/promise').when;
 
 // Internal deps
 var validateToken = require('./lib/validateToken.js'),
@@ -116,7 +116,7 @@ function AuthRequired(req, res, next) {
     if (!('authorization' in req.headers)) {
         res.status(401).send({error: 'Auth is required!'});
     }
-
+    console.log(req.headers.authorization)
     validateToken(config.services.auth.url, req.headers.authorization)
     .then(sessionObj => {
         if (!sessionObj) {

--- a/server.js
+++ b/server.js
@@ -72,7 +72,6 @@ if (cliOptions.dev) {
 // multipart transfers.
 let storage = multer.diskStorage({
     destination: (req, file, cb) => {
-        console.log(req.session)
         // if multiple files, take path of first
         let reqPath = req.body.destPath;
         let path = reqPath instanceof Array ? reqPath[0] : reqPath;
@@ -348,8 +347,6 @@ app.get('/list/*', AuthRequired, (req, res) => {
 
         const rootDir = config.ftpRoot,
             userDir = [rootDir, user].join('/');
-
-        console.log(req.files)
 
         req.files.forEach(f => {
             log.push(f.reqPath);

--- a/server.js
+++ b/server.js
@@ -115,6 +115,7 @@ function AuthRequired(req, res, next) {
     // if no token at all, return 401
     if (!('authorization' in req.headers)) {
         res.status(401).send({error: 'Auth is required!'});
+        return;
     }
     validateToken(config.services.auth.url, req.headers.authorization)
     .then(sessionObj => {
@@ -127,9 +128,12 @@ function AuthRequired(req, res, next) {
         req.session = sessionObj;
 
         // safe to move along.
+        console.log('doing next step')
         next();
     }).catch(error => {
+        console.log('dealing with error')
         res.status(500).send({error: 'Unable to validate authentication credentials'});
+        return;
     });
 }
 

--- a/tests/test-api.spec.js
+++ b/tests/test-api.spec.js
@@ -39,7 +39,7 @@ var validAuthHeader = { 'Authorization': token }
 
 describe('KBase FTP API GET Requests', () => {
     describe('GET /', () => {
-        it('returns status code 404', done => {
+        it('returns status code 404', (done) => {
             r.get({url: url('/')}, (error, response, body) => {
                 expect(response.statusCode).toBe(404)
                 done()
@@ -48,7 +48,7 @@ describe('KBase FTP API GET Requests', () => {
     })
 
     describe('GET /test-service', () => {
-        it('returns status code 200 for /test-service', done => {
+        it('returns status code 200 for /test-service', (done) => {
             r.get({url: url('/test-service')}, (error, response, body) => {
                 expect(response.statusCode).toBe(200)
                 done()
@@ -57,21 +57,21 @@ describe('KBase FTP API GET Requests', () => {
     })
 
     describe('GET /test-auth', () => {
-        it('returns status code 500 for /test-auth with bad token', done => {
+        it('returns status code 500 for /test-auth with bad token', (done) => {
             r.get({url: url('/test-auth'), headers: {'Authorization': 'bad_token'}}, (error, response, body) => {
                 expect(response.statusCode).toBe(500)
                 done()
             })
         })
 
-        it('returns status code 401 for /test-auth with no token', done => {
+        it('returns status code 401 for /test-auth with no token', (done) => {
             r.get({url: url('/test-auth')}, (error, response, body) => {
                 expect(response.statusCode).toBe(401)
                 done()
             })
         })
 
-        it('returns status code 200 for /test-auth with good token', done => {
+        it('returns status code 200 for /test-auth with good token', (done) => {
             r.get({url: url('/test-auth'), headers: validAuthHeader}, (error, response, body) => {
                 expect(response.statusCode).toBe(200)
                 done()
@@ -80,7 +80,7 @@ describe('KBase FTP API GET Requests', () => {
     })
 
     describe('GET /import-jobs', () => {
-        it('returns current import-jobs, or an empty list', done => {
+        it('returns current import-jobs, or an empty list', (done) => {
             r.get({url: url('/import-jobs'), headers: validAuthHeader}, (error, response, body) => {
                 expect(response.statusCode).toBe(200)
                 const res = JSON.parse(body)
@@ -89,7 +89,7 @@ describe('KBase FTP API GET Requests', () => {
             })
         })
 
-        it('returns 401 without a token', done => {
+        it('returns 401 without a token', (done) => {
             r.get({url: url('/import-jobs')}, (error, response, body) => {
                 expect(response.statusCode).toBe(401)
                 done()
@@ -98,14 +98,14 @@ describe('KBase FTP API GET Requests', () => {
     })
 
     describe('GET /import-job/:jobid', () => {
-        it('returns 404 if parameter is missing', done => {
+        it('returns 404 if parameter is missing', (done) => {
             r.get({url: url('/import-job'), headers: validAuthHeader}, (error, response, body) => {
                 expect(response.statusCode).toBe(404)
                 done()
             })
         })
 
-        it('returns 500 for invalid id', done => {
+        it('returns 500 for invalid id', (done) => {
             const jobId = '123'
             r.get({url: url('/import-job/' + jobId), headers: validAuthHeader}, (error, response, body) => {
                 expect(response.statusCode).toBe(500)
@@ -116,28 +116,28 @@ describe('KBase FTP API GET Requests', () => {
     })
 
     describe('GET /list', () => {
-        it('returns 401 with missing auth headers', done => {
+        it('returns 401 with missing auth headers', (done) => {
             r.get({url: url('/list/' + testUser)}, (error, response, body) => {
                 expect(response.statusCode).toBe(401)
                 done()
             })
         })
 
-        it('returns 403 with token/path root name mismatch', done => {
+        it('returns 403 with token/path root name mismatch', (done) => {
             r.get({url: url('/list/notauser'), headers: validAuthHeader}, (error, response, body) => {
                 expect(response.statusCode).toBe(403)
                 done()
             })
         })
 
-        it('returns 404 with missing path', done => {
+        it('returns 404 with missing path', (done) => {
             r.get({url: url('/list'), headers: validAuthHeader}, (error, response, body) => {
                 expect(response.statusCode).toBe(404)
                 done()
             })
         })
 
-        it('returns a list of files with proper path', done => {
+        it('returns a list of files with proper path', (done) => {
             const keyList = ['name', 'path', 'mtime', 'isFolder', 'size'].sort()
             r.get({url: url('/list/' + testUser), headers: validAuthHeader}, (error, response, body) => {
                 expect(response.statusCode).toBe(200)
@@ -155,7 +155,27 @@ describe('KBase FTP API GET Requests', () => {
 
 describe('KBase FTP POST Requests', () => {
     describe('POST /upload', () => {
-
+        it('Should work on the happy path for a simple file', (done) => {
+            var formData = {
+                destPath: '/' + testUser,
+                username: testUser,
+                uploads: [
+                    fs.createReadStream('./tests/test_data_file.txt')
+                ]
+            }
+            r.post({url: url('/upload'),
+                    headers: validAuthHeader,
+                    formData: formData},
+                    (error, response, body) => {
+                expect(response.statusCode).toBe(200)
+                console.log(body)
+                const result = JSON.parse(body)
+                expect(result.length).toBe(1)
+                var resultKeys = ['path', 'name', 'size', 'mtime'].sort()
+                expect(Object.keys(result[0]).sort()).toEqual(resultKeys)
+                done()
+            })
+        })
     })
 
     describe('POST /import-jobs', () => {

--- a/tests/test-api.spec.js
+++ b/tests/test-api.spec.js
@@ -6,9 +6,29 @@ var r = require('request'),
     fs = require('fs')
 
 var baseUrl = 'http://0.0.0.0:3000',
-    testConfig = JSON.parse(fs.readFileSync('tests/test-cfg.json', 'utf8')),
-    token = testConfig.authToken,
+    token = null,
+    testUser = null
+try {
+    var testConfig = JSON.parse(fs.readFileSync('tests/test-cfg.json', 'utf8'))
+    token = testConfig.authToken
+    if (token === null || token === undefined) {
+        throw new Error("Your test-cfg.json file must have a valid authToken value.")
+    }
     testUser = testConfig.userId
+    if (testUser === null || testUser === undefined) {
+        throw new Error("Your test-cfg.json file must have a valid user id.")
+    }
+} catch (e) {
+    if (e.code === "ENOENT") {
+        console.error("There needs to be a test-cfg.json file with authToken and userId keys.")
+    }
+    else {
+        console.error(e)
+    }
+    console.error("Please see README.md for details.")
+    process.exit(1)
+}
+
 console.log('\n\x1b[36m'+'using testing token:'+'\x1b[0m', token)
 console.log('\n\x1b[36m'+'using test user:'+'\x1b[0m', testUser)
 

--- a/tests/test-api.spec.js
+++ b/tests/test-api.spec.js
@@ -84,7 +84,7 @@ describe('KBase FTP API GET Requests', () => {
             r.get({url: url('/import-jobs'), headers: validAuthHeader}, (error, response, body) => {
                 expect(response.statusCode).toBe(200)
                 const res = JSON.parse(body)
-                expect(res).toEqual({result: []})
+                expect(res.result).toEqual(jasmine.any(Array))
                 done()
             })
         })

--- a/tests/test-api.spec.js
+++ b/tests/test-api.spec.js
@@ -1,26 +1,92 @@
-var request = require('request'),
-    fs = require('fs');
+/*global process*/
+/*eslint white:true,node:true,single:true,multivar:true,es6:true*/
 
-var url = "http://0.0.0.0:3000/v0/";
+var r = require('request'),
+    fs = require('fs')
 
-var token = fs.readFileSync('dev-user-token', 'utf8');
+var baseUrl = "http://0.0.0.0:3000",
+    token = fs.readFileSync('dev-user-token', 'utf8').trim();
 console.log('\n\x1b[36m'+'using testing token:'+'\x1b[0m', token, '\n')
 
-var get = request.defaults({
-    method: "GET",
-    headers: {
-        'Authorization': token.trim(),
-        'Content-type': 'application/json'
-    }
-})
 
-describe("KBase FTP API GET Requests", function() {
-    describe("GET /", function() {
-        it("returns status code 200", function(done) {
-            get({url: url}, function(error, response, body) {
-                expect(response.statusCode).toBe(404);
-                done();
-            });
-        });
-    });
-});
+// var r = request.defaults()
+
+var url = path => baseUrl + path
+
+// var get = function(path,
+//
+//
+//
+// var get = request.defaults({
+//     method: "GET",
+//     headers: {
+//         'Authorization': token.trim(),
+//         'Content-type': 'application/json'
+//     }
+// })
+
+// get /
+// get test-service
+// get test-auth
+// get list
+// post upload
+// post import-jobs
+// get import-jobs
+// get import-job/:jobid
+// delete import-job/:jobid
+
+
+describe('KBase FTP API GET Requests', () => {
+    describe('GET /', () => {
+        it('returns status code 404', (done) => {
+            r.get({url: url('/')}, (error, response, body) => {
+                expect(response.statusCode).toBe(404)
+                done()
+            })
+        })
+    })
+
+    describe('GET /test-service', () => {
+        it('returns status code 200 for /test-service', (done) => {
+            r.get({url: url('/test-service')}, (error, response, body) => {
+                expect(response.statusCode).toBe(200)
+                done()
+            })
+        })
+    })
+
+    describe('GET /test-auth', () => {
+        it('returns status code 500 for /test-auth with bad token', (done) => {
+            r.get({url: url('/test-auth'), headers: {'Authorization': 'bad_token'}}, (error, response, body) => {
+                expect(response.statusCode).toBe(500)
+                done()
+            })
+        })
+
+        it('returns status code 401 for /test-auth with no token', (done) => {
+            r.get({url: url('/test-auth')}, (error, response, body) => {
+                expect(response.statusCode).toBe(401)
+                done()
+            })
+        })
+
+        it('returns status code 200 for /test-auth with good token', (done) => {
+            r.get({url: url('/test-auth'), headers: {'Authorization': 'RD47QBVL2TEH64L4WIEV7LJ66F7EH2NM'}}, (error, response, body) => {
+                expect(response.statusCode).toBe(200)
+                done()
+            })
+        })
+    })
+
+    describe('GET /import-jobs', () => {
+
+    })
+
+    describe('GET /list', () => {
+
+    })
+
+    describe('GET /import-job/:id', () => {
+
+    })
+})

--- a/tests/test-api.spec.js
+++ b/tests/test-api.spec.js
@@ -1,44 +1,22 @@
 /*global process*/
 /*eslint white:true,node:true,single:true,multivar:true,es6:true*/
+'use strict'
 
 var r = require('request'),
     fs = require('fs')
 
-var baseUrl = "http://0.0.0.0:3000",
+var baseUrl = 'http://0.0.0.0:3000',
     token = fs.readFileSync('dev-user-token', 'utf8').trim();
 console.log('\n\x1b[36m'+'using testing token:'+'\x1b[0m', token, '\n')
 
-
-// var r = request.defaults()
-
 var url = path => baseUrl + path
 
-// var get = function(path,
-//
-//
-//
-// var get = request.defaults({
-//     method: "GET",
-//     headers: {
-//         'Authorization': token.trim(),
-//         'Content-type': 'application/json'
-//     }
-// })
-
-// get /
-// get test-service
-// get test-auth
-// get list
-// post upload
-// post import-jobs
-// get import-jobs
-// get import-job/:jobid
-// delete import-job/:jobid
+var validAuthHeader = { 'Authorization': token }
 
 
 describe('KBase FTP API GET Requests', () => {
     describe('GET /', () => {
-        it('returns status code 404', (done) => {
+        it('returns status code 404', done => {
             r.get({url: url('/')}, (error, response, body) => {
                 expect(response.statusCode).toBe(404)
                 done()
@@ -47,7 +25,7 @@ describe('KBase FTP API GET Requests', () => {
     })
 
     describe('GET /test-service', () => {
-        it('returns status code 200 for /test-service', (done) => {
+        it('returns status code 200 for /test-service', done => {
             r.get({url: url('/test-service')}, (error, response, body) => {
                 expect(response.statusCode).toBe(200)
                 done()
@@ -56,22 +34,22 @@ describe('KBase FTP API GET Requests', () => {
     })
 
     describe('GET /test-auth', () => {
-        it('returns status code 500 for /test-auth with bad token', (done) => {
+        it('returns status code 500 for /test-auth with bad token', done => {
             r.get({url: url('/test-auth'), headers: {'Authorization': 'bad_token'}}, (error, response, body) => {
                 expect(response.statusCode).toBe(500)
                 done()
             })
         })
 
-        it('returns status code 401 for /test-auth with no token', (done) => {
+        it('returns status code 401 for /test-auth with no token', done => {
             r.get({url: url('/test-auth')}, (error, response, body) => {
                 expect(response.statusCode).toBe(401)
                 done()
             })
         })
 
-        it('returns status code 200 for /test-auth with good token', (done) => {
-            r.get({url: url('/test-auth'), headers: {'Authorization': 'RD47QBVL2TEH64L4WIEV7LJ66F7EH2NM'}}, (error, response, body) => {
+        it('returns status code 200 for /test-auth with good token', done => {
+            r.get({url: url('/test-auth'), headers: validAuthHeader}, (error, response, body) => {
                 expect(response.statusCode).toBe(200)
                 done()
             })
@@ -79,14 +57,58 @@ describe('KBase FTP API GET Requests', () => {
     })
 
     describe('GET /import-jobs', () => {
+        it('returns current import-jobs, or an empty list', done => {
+            r.get({url: url('/import-jobs'), headers: validAuthHeader}, (error, response, body) => {
+                expect(response.statusCode).toBe(200)
+                const res = JSON.parse(body)
+                expect(res).toEqual({result: []})
+                done()
+            })
+        })
 
+        it('returns 401 without a token', done => {
+            r.get({url: url('/import-jobs')}, (error, response, body) => {
+                expect(response.statusCode).toBe(401)
+                done()
+            })
+        })
+    })
+
+    describe('GET /import-job/:jobid', () => {
+        it('returns 404 if parameter is missing', done => {
+            r.get({url: url('/import-job'), headers: validAuthHeader}, (error, response, body) => {
+                expect(response.statusCode).toBe(404)
+                done()
+            })
+        })
+
+        it('returns 500 for invalid id', done => {
+            const jobId = '123'
+            r.get({url: url('/import-job/' + jobId), headers: validAuthHeader}, (error, response, body) => {
+                expect(response.statusCode).toBe(500)
+                const res = JSON.parse(body)
+                done()
+            })
+        })
     })
 
     describe('GET /list', () => {
 
     })
+})
 
-    describe('GET /import-job/:id', () => {
+describe('KBase FTP POST Requests', () => {
+    describe('POST /upload', () => {
+
+    })
+
+    describe('POST /import-jobs', () => {
+
+    })
+})
+
+describe('KBase FTP DELETE Requests', () => {
+    describe('DELETE /import-job/:jobid', () => {
 
     })
 })

--- a/tests/test_data_file.txt
+++ b/tests/test_data_file.txt
@@ -1,0 +1,1 @@
+this is a test file.


### PR DESCRIPTION
This will be the PR that updates this service to use the new authentication system. This change is not really intended to be backward-compatible.

Still to do:
- [x] Use Auth2 for Authorization header validation and fetching session info
- [x] Handle fetching globus identities from KBase auth (if available)
- [x] Write tests that exercise the whole service (there's basically no tests now, and with a service as light as this, that's kinda tragic).
~~- [ ] Handle service tokens~~ not necessary
